### PR TITLE
split compile_list because of compile error in client

### DIFF
--- a/app/compile_list
+++ b/app/compile_list
@@ -10,17 +10,3 @@ db/db.ts
 test/db/db.ts
 test/routes/api.ts
 test/api/dcase.ts
-public/javascripts/ads.ts
-public/javascripts/adsComponentView.ts
-public/javascripts/animation.ts
-public/javascripts/api.ts
-public/javascripts/color.ts
-public/javascripts/dcaseviewer-addons.ts
-public/javascripts/dcaseviewer.ts
-public/javascripts/dnode.ts
-public/javascripts/gsnshape.ts
-public/javascripts/handler.ts
-public/javascripts/importfile.ts
-public/javascripts/index.ts
-public/javascripts/router.ts
-public/javascripts/timeline.ts

--- a/app/compile_list_public
+++ b/app/compile_list_public
@@ -1,0 +1,14 @@
+public/javascripts/ads.ts
+public/javascripts/adsComponentView.ts
+public/javascripts/animation.ts
+public/javascripts/api.ts
+public/javascripts/color.ts
+public/javascripts/dcaseviewer-addons.ts
+public/javascripts/dcaseviewer.ts
+public/javascripts/dnode.ts
+public/javascripts/gsnshape.ts
+public/javascripts/handler.ts
+public/javascripts/importfile.ts
+public/javascripts/index.ts
+public/javascripts/router.ts
+public/javascripts/timeline.ts


### PR DESCRIPTION
クライアントサイドをtypescriptに移植するにあたり、
コンパイルエラーが大量に出るのでとりあえず分割しました。
今後はclient_porting_typescriptブランチにてtypescriptへの移植を行い、
コンパイルエラーがなくなり次第masterへmergeします。
