### PR TITLE
サーバ側のcommitでenbug

### DIFF
--- a/app/api/dcase.js
+++ b/app/api/dcase.js
@@ -171,7 +171,7 @@ function commit(params, callback) {
     var commitDAO = new model_commit.CommitDAO(con);
     con.begin(function (err, result) {
         commitDAO.commit(userId, params.commitId, params.commitMessage, params.contents, function (err, result) {
-            con.commit(function (err, result) {
+            con.commit(function (err, _result) {
                 if(err) {
                     callback.onFailure(err);
                     return;

--- a/app/api/dcase.ts
+++ b/app/api/dcase.ts
@@ -161,7 +161,7 @@ export function commit(params: any, callback: type.Callback) {
 	con.begin((err, result) => {
 		// _commit(con, params.commitId, params.commitMessage, params.contents, (err, result) => {
 		commitDAO.commit(userId, params.commitId, params.commitMessage, params.contents, (err, result) => {
-			con.commit((err, result) =>{
+			con.commit((err, _result) =>{
 				if (err) {
 					callback.onFailure(err);
 					return;


### PR DESCRIPTION
@hisaboh 
app/api/dcase.tsの169行目付近のcallback.onSuccessに渡すresultは、
con.commit((err,result))のresultではなく
commitDAO.commit(... result)の方のresultを渡すものだと思います。

とりあえず_resultに変更して、動作を確認しました。
レビューお願いします。
